### PR TITLE
Fix current setting URI

### DIFF
--- a/script.js
+++ b/script.js
@@ -337,7 +337,10 @@ function refresh(){
             saveArray[i][setting] = extra[setting]
         })
     });
-    $("#saveURL").val("https://multiviewbeta.multicam.media?Settings=" + encodeURIComponent(JSON.stringify(saveArray)))
+    $("#saveURL").val(`${window.location.href.split('?')[0]}?Settings=${encodeURIComponent(JSON.stringify(saveArray))}`)
+    $("#saveURL").focus(function(){
+        $(this).select();
+    })
     clockTick();
     $(".outerContainer").html("")
     multiViewOverlays.forEach(overlay => {


### PR DESCRIPTION
Hello, Thank you for develop awesome tool for vMix! We're using this tool in production.

I would like you to fix Save setting URL, which uses beta URI currently.
I'm using this for my personal vMix assist utility(https://github.com/FlowingSPDG/vmix-utility).
that means URI might be different from current one.

Also I've added focus for saveURL element for better copy n paste operation.

Thank you!